### PR TITLE
Cargo.toml: disable reqwest default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ multipart = ["reqwest/multipart"]
 [dependencies]
 http = "0.2.1"
 oauth1-request = "0.3.3"
-reqwest = { version = "0.11.10" }
+reqwest = { version = "0.11.10", default-features = false }
 serde = "1.0.116"
 serde_urlencoded = "0.7.0"
 url = "2.2.0"


### PR DESCRIPTION
I'm using Reqwest with `rustls` instead of `openssl` and currently `reqwest-oauth1` tries to pull in `openssl` again.

The fewer the number of features also mean the faster the compile time :)