### PR TITLE
Impl Deserialize for TokenResponse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ multipart = ["reqwest/multipart"]
 http = "0.2.1"
 oauth1-request = "0.3.3"
 reqwest = { version = "0.11.10", default-features = false }
-serde = "1.0.116"
+serde = { version = "1.0.116", features = ["derive"] }
 serde_urlencoded = "0.7.0"
 url = "2.2.0"
 async-trait = "0.1.40"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,18 @@ async fn acquire_twitter_key() -> Result<(), reqwest_oauth1::Error> {
         .parse_oauth_token()
         .await?;
 
+    /*
+    or
+
+    let resp = client
+        .oauth1(secrets)
+        .get(endpoint_reqtoken)
+        .query(&[("oauth_callback", "oob")])
+        .send()
+        .await?;
+    let resp = serde_urlencoded::from_str::<reqwest_oauth1::TokenResponse>(resp.text().await?.as_str()).unwrap();
+    */
+
     // step 2. acquire user pin
     let endpoint_authorize = "https://api.twitter.com/oauth/authorize?oauth_token=";
     println!("please access to: {}{}", endpoint_authorize, resp.oauth_token);


### PR DESCRIPTION
Hi @karno

I want use in axum.
But `axum::handler::Handler` require Send, and `TokenReaderFuture` is `#[async_trait(?Send)]`.
So, I have added `Deserialize` derive to the `TokenResponse`, then I can use serde_urlencoded to de it.

Please review it, thank you.
